### PR TITLE
Makes args parameter optional in ActiveResponse

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/model/ActiveResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/ActiveResponse.kt
@@ -36,7 +36,7 @@ data class ActiveResponse(
     val type: String,
     val statefulTimeout: Int? = null,
     val executable: String,
-    val args: String,
+    val args: String? = null,
     val location: String,
     val agentId: String? = null
 ) : BaseConfigData {
@@ -107,7 +107,6 @@ data class ActiveResponse(
             }
             type ?: throw IllegalArgumentException("type field absent")
             executable ?: throw IllegalArgumentException("executable field absent")
-            args ?: throw IllegalArgumentException("extra_args field absent")
             location ?: throw IllegalArgumentException("location field absent")
             return ActiveResponse(/*name*/ type, statefulTimeout, executable, args, location, agentId)
         }
@@ -133,7 +132,7 @@ data class ActiveResponse(
         output.writeString(type)
         output.writeOptionalInt(statefulTimeout)
         output.writeString(executable)
-        output.writeString(args)
+        output.writeOptionalString(args)
         output.writeString(location)
         output.writeOptionalString(agentId)
     }
@@ -145,7 +144,6 @@ data class ActiveResponse(
         builder!!
         builder.startObject()
             .field(NotificationConstants.EXECUTABLE_TAG, executable)
-            .field(NotificationConstants.EXTRA_ARGS_TAG, args)
             .field(NotificationConstants.LOCATION_TAG, location)
             .field(NotificationConstants.TYPE_TAG, type)
         if (agentId != null) {
@@ -153,6 +151,9 @@ data class ActiveResponse(
         }
         if (statefulTimeout != null) {
             builder.field(NotificationConstants.STATEFUL_TIMEOUT_TAG, statefulTimeout)
+        }
+        if (args != null) {
+            builder.field(NotificationConstants.EXTRA_ARGS_TAG, args)
         }
         return builder.endObject()
     }


### PR DESCRIPTION
### Description

The default value for the location is changed when creating an active response, and if it is an empty string, a null value is returned

### Related Issues

Closes https://github.com/wazuh/wazuh-dashboard-notifications/issues/19

### Screenshots

<img width="892" height="1030" alt="image" src="https://github.com/user-attachments/assets/c44cf52f-db89-434c-af2c-7d4948aa2108" />

<img width="2292" height="769" alt="image" src="https://github.com/user-attachments/assets/718b2f98-e81c-47aa-9120-c17587235d8d" />

