### PR TITLE
Skip validation for template placeholders

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -161,6 +161,11 @@ data class DocLevelQuery(
         }
 
         private fun validateQueryTag(stringVal: String) {
+            // Skip validation for template placeholders (e.g., "{{ field.path }}")
+            // that will be resolved at finding enrichment time.
+            if (stringVal.contains("{{")) {
+                return
+            }
             for (inValidChar in INVALID_CHARACTERS) {
                 if (stringVal.contains(inValidChar)) {
                     throw IllegalArgumentException(


### PR DESCRIPTION
### Description
This PR allows us to skip validation for template placeholders, that will be resolved at finding enrichment time it is needed since if not we were not able to generate findings or detectors with rules with this dynamic mappings fields

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-security-analytics/issues/181
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).