### PR TITLE
Extend alerting commons to include new AR monitor type

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
@@ -64,8 +64,11 @@ class IndexMonitorRequest : ActionRequest {
 
     private fun hasDocLeveMonitorInput() = monitor.inputs.isNotEmpty() && monitor.inputs[0] is DocLevelMonitorInput
 
-    private fun isDocLevelMonitor() =
-        monitor.monitorType.isNotBlank() && isMonitorOfStandardType(monitor.monitorType) && Monitor.MonitorType.valueOf(this.monitor.monitorType.uppercase(Locale.ROOT)) == Monitor.MonitorType.DOC_LEVEL_MONITOR
+    private fun isDocLevelMonitor(): Boolean {
+        if (monitor.monitorType.isBlank() || !isMonitorOfStandardType(monitor.monitorType)) return false
+        val type = Monitor.MonitorType.valueOf(this.monitor.monitorType.uppercase(Locale.ROOT))
+        return type == Monitor.MonitorType.DOC_LEVEL_MONITOR
+    }
 
     private fun isMonitorOfStandardType(monitorType: String): Boolean {
         val standardMonitorTypes = Monitor.MonitorType.values().map { it.value.uppercase(Locale.ROOT) }.toSet()

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -67,6 +67,8 @@ data class Monitor(
                     require(trigger is QueryLevelTrigger) { "Incompatible trigger [${trigger.id}] for monitor type [$monitorType]" }
                 MonitorType.DOC_LEVEL_MONITOR.value ->
                     require(trigger is DocumentLevelTrigger) { "Incompatible trigger [${trigger.id}] for monitor type [$monitorType]" }
+                MonitorType.ACTIVE_RESPONSE_MONITOR.value ->
+                    require(trigger is DocumentLevelTrigger) { "Incompatible trigger [${trigger.id}] for monitor type [$monitorType]" }
             }
         }
         if (enabled) {
@@ -130,7 +132,8 @@ data class Monitor(
         QUERY_LEVEL_MONITOR("query_level_monitor"),
         BUCKET_LEVEL_MONITOR("bucket_level_monitor"),
         CLUSTER_METRICS_MONITOR("cluster_metrics_monitor"),
-        DOC_LEVEL_MONITOR("doc_level_monitor");
+        DOC_LEVEL_MONITOR("doc_level_monitor"),
+        ACTIVE_RESPONSE_MONITOR("active_response_monitor");
 
         override fun toString(): String {
             return value


### PR DESCRIPTION
### Description
This PR extends alerting commons to include the new monitor type created for AR

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-alerting/issues/8

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).