### PR TITLE
Modify commons to detect internal calls

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
@@ -20,6 +20,8 @@ class IndexMonitorRequest : ActionRequest {
     val method: RestRequest.Method
     var monitor: Monitor
     val rbacRoles: List<String>?
+    /** When true the request originates from an internal plugin (e.g. SAP) and should bypass the max-monitors limit. */
+    val internalCaller: Boolean
 
     constructor(
         monitorId: String,
@@ -28,7 +30,8 @@ class IndexMonitorRequest : ActionRequest {
         refreshPolicy: WriteRequest.RefreshPolicy,
         method: RestRequest.Method,
         monitor: Monitor,
-        rbacRoles: List<String>? = null
+        rbacRoles: List<String>? = null,
+        internalCaller: Boolean = false
     ) : super() {
         this.monitorId = monitorId
         this.seqNo = seqNo
@@ -37,6 +40,7 @@ class IndexMonitorRequest : ActionRequest {
         this.method = method
         this.monitor = monitor
         this.rbacRoles = rbacRoles
+        this.internalCaller = internalCaller
     }
 
     @Throws(IOException::class)
@@ -47,7 +51,8 @@ class IndexMonitorRequest : ActionRequest {
         refreshPolicy = WriteRequest.RefreshPolicy.readFrom(sin),
         method = sin.readEnum(RestRequest.Method::class.java),
         monitor = Monitor.readFrom(sin) as Monitor,
-        rbacRoles = sin.readOptionalStringList()
+        rbacRoles = sin.readOptionalStringList(),
+        internalCaller = sin.readBoolean()
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -84,5 +89,6 @@ class IndexMonitorRequest : ActionRequest {
         out.writeEnum(method)
         monitor.writeTo(out)
         out.writeOptionalStringCollection(rbacRoles)
+        out.writeBoolean(internalCaller)
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
@@ -20,6 +20,7 @@ class IndexMonitorRequest : ActionRequest {
     val method: RestRequest.Method
     var monitor: Monitor
     val rbacRoles: List<String>?
+
     /** When true the request originates from an internal plugin (e.g. SAP) and should bypass the max-monitors limit. */
     val internalCaller: Boolean
 


### PR DESCRIPTION
### Description
This PR adds a new `internalCaller` variable to detect internal calls

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1589
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).