### PR TITLE
Removed test results upload

### DIFF
--- a/.github/workflows/5_builderpackage_common_utils.yml
+++ b/.github/workflows/5_builderpackage_common_utils.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-${{ matrix.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v5

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -80,7 +80,7 @@ jobs:
           export GPG_TTY=$(tty)
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Using workflow-specific GITHUB_TOKEN because currently CI_WAZUHCI_BUMPER_TOKEN
           # doesn't have all the necessary permissions

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -27,10 +27,3 @@ jobs:
       - name: Run Gradle check
         run: ./gradlew check
 
-      - name: Upload test results
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: test-results
-          overwrite: 'true'
-          path: build/test-results/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get version
         id: version

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: lychee Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-  "version": "5.0.0",
-  "stage": "beta3"
+  "version": "5.0.1",
+  "stage": "alpha0"
 }


### PR DESCRIPTION
### Description
Due to issue https://github.com/wazuh/internal-devel-requests/issues/5304, we need to migrate the artifacts uploaded by our workflows to S3. Since the test results upload step in` 5_testintegration_gradlecheck.yml `isn't working correctly, it has been removed from the workflow, so we don't need to migrate it to S3.

### Issues Resolved
https://github.com/wazuh/internal-devel-requests/issues/5304
