### PR TITLE
Restructure CHANGELOG.md and add tag-aware workflow references to the bumper

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -16,7 +16,7 @@ on:
         type: string
       tag:
         description: 'Set to true when this bump is preparing a tag release'
-        default: false
+        default: true
         required: false
         type: boolean
       issue-link:

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -14,6 +14,11 @@ on:
         default: ''
         required: false
         type: string
+      tag:
+        description: 'Set to true when this bump is preparing a tag release'
+        default: false
+        required: false
+        type: boolean
       issue-link:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
@@ -92,9 +97,17 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          TAG: ${{ inputs.tag }}
         run: |
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
+          tag=${{ env.TAG }}
+          set_as_main=${{ inputs.set_as_main }}
+
+          if [[ "$tag" == "true" && "$set_as_main" == "true" ]]; then
+            echo "Error: 'tag' and 'set_as_main' inputs cannot both be true."
+            exit 1
+          fi
 
           # In revert mode, version/stage are not required
           if [[ "${{ inputs.revert }}" != "true" ]]; then
@@ -102,8 +115,14 @@ jobs:
               echo "Error: Version and stage must be provided. Got version=${version} stage=${stage}"
               exit 1
             fi
-            echo "version=${version}" >> $GITHUB_OUTPUT
-            echo "stage=${stage}" >> $GITHUB_OUTPUT
+            script_params="--version ${version} --stage ${stage}"
+            if [[ "$tag" == "true" ]]; then
+              script_params="${script_params} --tag"
+            fi
+            if [[ "$set_as_main" == "true" ]]; then
+              script_params="${script_params} --set-as-main"
+            fi
+            echo "script_params=${script_params}" >> $GITHUB_OUTPUT
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
@@ -125,12 +144,7 @@ jobs:
         if: inputs.revert != true
         run: |
           echo "Running bump script"
-          set_as_main=${{ inputs.set_as_main }}
-          script_params=("${{ steps.vars.outputs.version }}" "${{ steps.vars.outputs.stage }}" ${{ steps.vars.outputs.date }})
-          if [[ "$set_as_main" == "true" ]]; then
-            script_params+=("--set-as-main")
-          fi
-          bash "${{ env.BUMP_SCRIPT_PATH }}" "${script_params[@]}"
+          bash "${{ env.BUMP_SCRIPT_PATH }}" ${{ steps.vars.outputs.script_params }}
 
       - name: Check for changes
         id: check_changes

--- a/.github/workflows/5_codequality_email.yml
+++ b/.github/workflows/5_codequality_email.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@main
+      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@5.0.0
         with:
             email_domain: 'wazuh.com, @users.noreply.github.com'
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,7 @@
 - Add Support Revert Bump Functionality [(#30)](https://github.com/wazuh/wazuh-indexer-common-utils/pull/30)
 - Add dedicated monitor for Active Response [(#68)](https://github.com/wazuh/wazuh-indexer-common-utils/pull/68)
 
-### Dependencies
-
--
-
 ### Changed
-
--
-
-### Deprecated
 
 -
 
@@ -25,11 +17,6 @@
 ### Fixed
 - Fix codeql issues [(#17)](https://github.com/wazuh/wazuh-indexer-common-utils/pull/17)
 - Fix bumper workflow merge step [(#27)](https://github.com/wazuh/wazuh-indexer-common-utils/pull/27)
-
-  
-
-### Security
-
 
 ## Prior versions
 - []()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# CHANGELOG
-
-All notable changes to this project are documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
-
 ## [v5.0.0]
 
 ### Added
@@ -39,5 +33,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Prior versions
 - []()
-
-[Unreleased 5.0.x]: https://github.com/wazuh/wazuh-indexer-common-utils/compare/fbaae1d440dadf8491fa68145a465b09c6dc118e...5.0.0

--- a/tools/changelog_sync.sh
+++ b/tools/changelog_sync.sh
@@ -39,8 +39,6 @@ function fetch_stable_tags() {
 function build_prior_versions() {
     local version="$1"
     local major="${version%%.*}"
-    local target_rest="${version#*.}"
-    local target_minor="${target_rest%%.*}"
 
     local tags
     tags="$(fetch_stable_tags)"
@@ -54,7 +52,7 @@ function build_prior_versions() {
         [[ "$t_major" != "$major" ]] && continue
         rest="${stripped#*.}"
         t_minor="${rest%%.*}"
-        [[ "$t_minor" == "$target_minor" ]] && continue
+        [[ "$stripped" == "$version" ]] && continue
         t_patch="${rest#*.}"
         grouped+="${t_minor}\t${t_patch}\t${name}\n"
     done <<< "$tags"

--- a/tools/changelog_sync.sh
+++ b/tools/changelog_sync.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# =========================
+# Changelog Sync
+# =========================
+# Reinitializes CHANGELOG.md to the standard empty template for the given
+# version, with a freshly computed "Prior versions" section. Called by
+# repository_bumper.sh only when the version number actually changes (never
+# on a stage-only bump).
+#
+# Prior versions are discovered from git tags (not branches): the two most
+# recent minor versions below the one just bumped, listing every stable
+# patch tag found for each of them. If the repo has no stable tags yet,
+# the "## Prior versions" section is written with no entries under it.
+#
+# Arguments:
+# 1. The version just bumped to (e.g., 5.1.0)
+
+set -euo pipefail
+
+function log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] $1"
+}
+
+function get_repo_path() {
+    local remote_url
+    remote_url=$(git remote get-url origin)
+    remote_url="${remote_url%.git}"
+    remote_url="${remote_url#*github.com/}"
+    remote_url="${remote_url#*github.com:}"
+    echo "$remote_url"
+}
+
+function fetch_stable_tags() {
+    git ls-remote --tags origin | sed -E 's#^[0-9a-f]+[[:space:]]+refs/tags/##' \
+        | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' || true
+}
+
+function build_prior_versions() {
+    local version="$1"
+    local major="${version%%.*}"
+    local target_rest="${version#*.}"
+    local target_minor="${target_rest%%.*}"
+
+    local tags
+    tags="$(fetch_stable_tags)"
+    [[ -z "$tags" ]] && return 0
+
+    local name stripped t_major rest t_minor t_patch
+    local grouped=""
+    while IFS= read -r name; do
+        stripped="${name#v}"
+        t_major="${stripped%%.*}"
+        [[ "$t_major" != "$major" ]] && continue
+        rest="${stripped#*.}"
+        t_minor="${rest%%.*}"
+        [[ "$t_minor" == "$target_minor" ]] && continue
+        t_patch="${rest#*.}"
+        grouped+="${t_minor}\t${t_patch}\t${name}\n"
+    done <<< "$tags"
+
+    [[ -z "$grouped" ]] && return 0
+
+    local minor
+    for minor in $(printf '%b' "$grouped" | cut -f1 | sort -run | head -2); do
+        printf '%b' "$grouped" | awk -F'\t' -v m="$minor" '$1 == m' | sort -t$'\t' -k2 -rn | cut -f3
+    done
+}
+
+function render_changelog() {
+    local version="$1"
+    local repo_path
+    repo_path="$(get_repo_path)"
+
+    {
+        echo "## [v${version}]"
+        echo ""
+        echo "### Added"
+        echo ""
+        echo "### Changed"
+        echo ""
+        echo "### Removed"
+        echo ""
+        echo "### Fixed"
+        echo ""
+        echo "## Prior versions"
+
+        local prior
+        prior="$(build_prior_versions "$version")"
+        if [[ -n "$prior" ]]; then
+            while IFS= read -r name; do
+                echo "- [${name}](https://github.com/${repo_path}/blob/${name}/CHANGELOG.md)"
+            done <<< "$prior"
+        fi
+    } > CHANGELOG.md
+
+    log "Reinitialized CHANGELOG.md for v${version}"
+}
+
+function main() {
+    if [[ $# -ne 1 ]]; then
+        log "Usage: $0 <version>"
+        exit 1
+    fi
+
+    render_changelog "$1"
+}
+
+main "$@"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -3,23 +3,22 @@
 # =========================
 # Repository Bumper Script
 # =========================
-# This script updates the VERSION.json file for a new version release.
+# Updates VERSION.json for a new version release, then (depending on flags)
+# reinitializes CHANGELOG.md and pins workflow references to the right
+# branch/tag.
 #
-# It takes three arguments:
-# 1. The new version to set (e.g., 4.5.0)
-# 2. The new stage to set (alpha, beta, rc, stable)
-#
+# Usage: repository_bumper.sh --version VERSION --stage STAGE [--tag] [--set-as-main]
 
 set -euo pipefail
 
-# ====
-# Print usage instructions
-# ====
 function usage() {
-    echo "Usage: $0 <version> <stage> [--set-as-main]"
-    echo "  version:  The new version to set in VERSION.json (e.g., 4.5.0)"
-    echo "  stage:    The new stage to set in VERSION.json (alpha, beta, rc, stable)"
-    echo "  --set-as-main: (Optional) Enable main branch mode: bump version values only,"
+    echo "Usage: $0 --version VERSION --stage STAGE [--tag] [--set-as-main]"
+    echo "  --version VERSION   The new version to set in VERSION.json (e.g., 4.5.0)"
+    echo "  --stage STAGE       The new stage to set in VERSION.json (alpha0, beta1, rc1, stable...)"
+    echo "  --tag               Pin workflow references using tag format (v{version}-{stage})"
+    echo "                      instead of branch format ({version})"
+    echo "  --set-as-main       Enable main branch mode: bump version values only, keep"
+    echo "                      workflow references pointing to main"
     exit 1
 }
 
@@ -93,7 +92,6 @@ function validate_inputs() {
     fi
 }
 
-
 # ====
 # Check if jq is installed
 # ====
@@ -102,6 +100,13 @@ function check_jq_installed() {
         log "Error: 'jq' is not installed. Please install it to use this script."
         exit 1
     fi
+}
+
+# ====
+# Print the version currently set in VERSION.json
+# ====
+function current_version() {
+    jq -r '.version' VERSION.json
 }
 
 # ====
@@ -126,31 +131,33 @@ function update_version_file() {
     log "Updated $file with version=$version and stage=$stage"
 }
 
-
 # ====
-# Main logic
+# Parse command-line arguments
+# Globals:
+#   arg_version, arg_stage, arg_tag, arg_set_as_main
 # ====
-function main() {
-    if [ "$#" -lt 2 ]; then
-        log "Error: Invalid number of arguments. Expected at least 2, got $#."
-        usage
-    fi
+function parse_args() {
+    declare -g arg_version=""
+    declare -g arg_stage=""
+    declare -g arg_tag=""
+    declare -g arg_set_as_main=""
 
-    if [[ $# -gt 3 ]]; then
-        log "Error: Too many arguments. Expected at most 3, got $#."
-        usage
-    fi
-
-    local version="$1"
-    local stage="$2"
-    local set_as_main=""
-
-    # Parse optional flags
-    shift 2
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --version)
+                arg_version="$2"
+                shift 2
+                ;;
+            --stage)
+                arg_stage="$2"
+                shift 2
+                ;;
+            --tag)
+                arg_tag="yes"
+                shift 1
+                ;;
             --set-as-main)
-                set_as_main="yes"
+                arg_set_as_main="yes"
                 shift 1
                 ;;
             *)
@@ -160,14 +167,52 @@ function main() {
         esac
     done
 
+    if [[ -z "$arg_version" || -z "$arg_stage" ]]; then
+        log "Error: --version and --stage are both required."
+        usage
+    fi
+
+    if [[ -n "$arg_tag" && -n "$arg_set_as_main" ]]; then
+        log "Error: --set-as-main cannot be used with --tag. --set-as-main keeps workflow" \
+             "references pointing to main; --tag exists to convert them to a tag reference," \
+             "which is never done on main."
+        exit 1
+    fi
+}
+
+# ====
+# Main logic
+# ====
+function main() {
+    parse_args "$@"
 
     init_logging
-    log "Starting update for VERSION.json with version=$version, stage=$stage"
+    log "Starting update for VERSION.json with version=$arg_version, stage=$arg_stage"
 
     navigate_to_project_root
     check_jq_installed
-    validate_inputs "$version" "$stage"
-    update_version_file "$version" "$stage"
+    validate_inputs "$arg_version" "$arg_stage"
+
+    local old_version
+    old_version="$(current_version)"
+
+    update_version_file "$arg_version" "$arg_stage"
+
+    if [[ "$arg_version" != "$old_version" ]]; then
+        log "Version changed: $old_version -> $arg_version"
+        bash "$(dirname "${BASH_SOURCE[0]}")/changelog_sync.sh" "$arg_version"
+    else
+        log "Version unchanged ($arg_version); stage-only bump."
+    fi
+
+    if [[ -z "$arg_set_as_main" ]]; then
+        local refs_args=("$arg_version" "$arg_stage")
+        [[ -n "$arg_tag" ]] && refs_args+=("--tag")
+        bash "$(dirname "${BASH_SOURCE[0]}")/workflow_refs_sync.sh" "${refs_args[@]}"
+    else
+        log "Main branch mode enabled: workflow references left pointing to main."
+    fi
+
     log "Update complete."
 }
 

--- a/tools/workflow_refs_sync.sh
+++ b/tools/workflow_refs_sync.sh
@@ -36,7 +36,7 @@ function find_referenced_repos() {
 
     [[ -z "$matches" ]] && return 0
 
-    printf '%s\n' "$matches" | sed -E 's#.*wazuh/([^/]+)/.*#\1#' | sort -u
+    printf '%s\n' "$matches" | sed -E 's#^uses:[[:space:]]*wazuh/([^/]+)/.*#\1#' | sort -u
 }
 
 function pin_repo_references() {

--- a/tools/workflow_refs_sync.sh
+++ b/tools/workflow_refs_sync.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# =========================
+# Workflow References Sync
+# =========================
+# Pins "uses: wazuh/<repo>/...@<ref>" reusable workflow/action references in
+# .github/workflows/*.yml to the current release. Matches both a still-
+# unpinned "@main" reference and any reference this script pinned on a
+# previous bump (branch-style or tag-style), so every bump converges
+# references to the current state regardless of what was there before.
+#
+# Called by repository_bumper.sh on every bump except when --set-as-main is
+# used (main's references to other repos' main are already correct).
+#
+# Does not verify that the referenced repo actually has that branch/tag —
+# it rewrites unconditionally, trusting the caller.
+#
+# Arguments:
+# 1. version (e.g. 5.1.0)
+# 2. stage (e.g. beta1)
+# Flags:
+#   --tag   Pin using tag format (v{version}-{stage}) instead of branch
+#           format ({version})
+
+set -euo pipefail
+
+REF_PATTERN='(main|v?[0-9]+\.[0-9]+\.[0-9]+(-[[:alnum:]]+)?)'
+
+function log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] $1"
+}
+
+function find_referenced_repos() {
+    local matches
+    matches=$(grep -rhoE "uses:[[:space:]]*wazuh/[^/[:space:]]+/[^[:space:]]*@${REF_PATTERN}" .github/workflows/*.yml 2>/dev/null || true)
+
+    [[ -z "$matches" ]] && return 0
+
+    printf '%s\n' "$matches" | sed -E 's#.*wazuh/([^/]+)/.*#\1#' | sort -u
+}
+
+function pin_repo_references() {
+    local repo="$1"
+    local bump_string="$2"
+    local escaped_bump_string
+    escaped_bump_string=$(printf '%s' "$bump_string" | sed -e 's/[\\&#]/\\&/g')
+
+    local f
+    for f in .github/workflows/*.yml; do
+        [[ -f "$f" ]] || continue
+        if grep -qE "uses:[[:space:]]*wazuh/${repo}/.*@${REF_PATTERN}" "$f"; then
+            sed -i -E "s#(uses:[[:space:]]*wazuh/${repo}/[^[:space:]]+)@${REF_PATTERN}#\1@${escaped_bump_string}#" "$f"
+            log "Pinned wazuh/$repo references to '$bump_string' in $f"
+        fi
+    done
+}
+
+function main() {
+    if [[ $# -lt 2 ]]; then
+        log "Usage: $0 <version> <stage> [--tag]"
+        exit 1
+    fi
+
+    local version="$1"
+    local stage="$2"
+    shift 2
+
+    local tag=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --tag)
+                tag="yes"
+                shift 1
+                ;;
+            *)
+                log "Error: Unknown argument '$1'."
+                exit 1
+                ;;
+        esac
+    done
+
+    local bump_string
+    if [[ -n "$tag" ]]; then
+        bump_string="v${version}-${stage}"
+    else
+        bump_string="${version}"
+    fi
+
+    local repo
+    while IFS= read -r repo; do
+        [[ -z "$repo" ]] && continue
+        pin_repo_references "$repo" "$bump_string"
+    done < <(find_referenced_repos)
+}
+
+main "$@"


### PR DESCRIPTION
### Description
Restructures `CHANGELOG.md` to the format required by the parent issue (no title, no description, no Unreleased link, only `Added`/`Changed`/`Removed`/`Fixed` sections), reinitializing it automatically whenever the version number changes and computing the `Prior versions` list from git tags. Also replaces the bumper's `@main`-only, branch-only reference pinning with a tag-aware mechanism: a new `--tag` flag on `repository_bumper.sh` pins cross-repo workflow references to either the current branch or a `v{version}-{stage}` tag.

### Issues Resolved
Resolves IDR5387