### PR TITLE
Set tag input default to false and revert bogus v5.0.0-rc1 references

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -16,7 +16,7 @@ on:
         type: string
       tag:
         description: 'Set to true when this bump is preparing a tag release'
-        default: true
+        default: false
         required: false
         type: boolean
       issue-link:

--- a/.github/workflows/5_codequality_email.yml
+++ b/.github/workflows/5_codequality_email.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@v5.0.0-rc1
+      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@5.0.0
         with:
             email_domain: 'wazuh.com, @users.noreply.github.com'
             github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The `tag` input in the bumper workflow defaulted to `true`, causing stage-only bumps to wrongly pin workflow references to a tag (`v5.0.0-rc1`) that doesn't exist yet. This PR sets the default to `false` and reverts those references back to `5.0.0`.

## Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1765
