### PR TITLE
Allow optional keyword/normalizer

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DataSources.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DataSources.kt
@@ -61,12 +61,26 @@ data class DataSources(
                 "Custom query index mappings are configurable only if a custom query index is configured too."
             }
             require(
-                queryIndexMappingsByType.size == 1 &&
-                    queryIndexMappingsByType.containsKey("text") &&
+                queryIndexMappingsByType.containsKey("text") &&
                     queryIndexMappingsByType.get("text")?.size == 1 &&
                     queryIndexMappingsByType.get("text")!!.containsKey("analyzer")
             ) {
-                "Custom query index mappings are currently configurable only for 'text' fields and mapping parameter can only be 'analyzer'"
+                "Custom query index mappings must include a 'text' field mapping whose only parameter is 'analyzer'"
+            }
+            // WCS string fields are mapped as 'keyword', so allow an optional 'keyword'
+            // mapping carrying a single 'normalizer' parameter.
+            require(
+                queryIndexMappingsByType.keys.all { it == "text" || it == "keyword" } &&
+                    (
+                        !queryIndexMappingsByType.containsKey("keyword") ||
+                            (
+                                queryIndexMappingsByType.get("keyword")?.size == 1 &&
+                                    queryIndexMappingsByType.get("keyword")!!.containsKey("normalizer")
+                                )
+                        )
+            ) {
+                "Custom query index mappings are configurable only for 'text' fields ('analyzer') " +
+                    "and optionally 'keyword' fields ('normalizer')"
             }
         }
     }


### PR DESCRIPTION
## Description

`DataSources.validate()` restricts `queryIndexMappingsByType` to `{text: {analyzer}}` and throws on anything else. Security Analytics needs to also configure a `keyword` field with a `normalizer` (to reverse the `_ws_` whitespace placeholder on keyword query-index fields). 

This PR enables us to include the `normalizer` field.

## Proposed Changes

- `queryIndexMappingsByType` (src/main/kotlin/org/opensearch/commons/alerting/model/DataSources.kt) validation changes:
  - **Allow** an optional `keyword` entry whose only parameter is `normalizer`.


## Results and Evidence

Validation in: https://github.com/wazuh/wazuh-indexer-security-analytics/issues/285#issuecomment-5250698665


## Artifacts Affected

- Common utils

## Configuration Changes

NA

## Documentation Updates

NA

## Tests Introduced

NA

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)