### PR TITLE
Report skipped bumps instead of failing the workflow

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -184,11 +184,14 @@ jobs:
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Error: The original PR for the bump was not found"
+            echo "The original PR for the bump was not found"
             echo "Searching merged PR from: $BUMP_BRANCH to ${{ github.ref_name }}"
-            exit 1
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
+          echo "pr_found=true" >> $GITHUB_OUTPUT
           echo "Original PR found: #$PR_NUMBER"
 
           MERGE_COMMIT=$(gh pr view $PR_NUMBER --json mergeCommit --jq '.mergeCommit.oid')
@@ -209,13 +212,15 @@ jobs:
           fi
 
       - name: Push changes
-        if: inputs.revert != true && steps.check_changes.outputs.has_changes == 'true' || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') ||
+            (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           git push origin ${{ steps.vars.outputs.branch_name }}
 
       - name: Create pull request
         id: create_pr
-        if: inputs.revert != true && steps.check_changes.outputs.has_changes == 'true' || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') ||
+            (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -228,7 +233,8 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
-        if: inputs.revert != true && steps.check_changes.outputs.has_changes == 'true' || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.check_changes.outputs.has_changes == 'true') ||
+            (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
@@ -250,3 +256,14 @@ jobs:
           echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
           echo "Revert bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log || true
+
+      - name: "Result: original bump pull request not found"
+        if: inputs.revert == true && steps.revert_step.outputs.pr_found == 'false'
+        run: echo "There is no original bump pull request to revert, nothing to do."
+
+      - name: "Result: no changes to commit"
+        if: >-
+          (inputs.revert != true && steps.check_changes.outputs.has_changes == 'false') ||
+          (inputs.revert == true && steps.revert_step.outputs.pr_found == 'true' &&
+          steps.revert_step.outputs.has_changes == 'false')
+        run: echo "The bump produced no changes, no pull request was created."


### PR DESCRIPTION
## Description

The repository bumper workflow fails with a `failure` conclusion in two harmless no-op situations, preventing the release orchestrator in `wazuh-qa-automation` from distinguishing between actual failures and runs that simply had nothing to do.

Closes #113

## Proposed Changes

- Replace `exit 1` with `exit 0` and output variables (`pr_found`, `has_changes`) in the `Revert references (Revert)` step when the original bump PR is not found.
- Add two `Result:` reporting steps with names matched by the orchestrator:
  - `"Result: original bump pull request not found"` — executed on revert when no original bump PR exists.
  - `"Result: no changes to commit"` — executed when a bump or revert produces no changes.

### Results and Evidence

### Results and Evidence

Workflow runs on test branches validating the scenarios described in the issue:

1. **Revert with no original bump PR** ([run](https://github.com/wazuh/wazuh-indexer-common-utils/actions/runs/31481184573)) — run ends as `success`, `Result: original bump pull request not found` is executed, Push/Create PR/Merge are skipped. No branch and no PR created.
2. **Bump with no changes** ([run](https://github.com/wazuh/wazuh-indexer-common-utils/actions/runs/31481284876)) — run ends as `success`, `Result: no changes to commit` is executed, no PR created.
3. **Normal bump** ([run](https://github.com/wazuh/wazuh-indexer-common-utils/actions/runs/31481189584)) — PR created and merged, neither Result step executed.
4. **Normal revert** ([run](https://github.com/wazuh/wazuh-indexer-common-utils/actions/runs/31595390071)) — revert PR created and merged, neither Result step executed.

Additional case covered ([run](https://github.com/wazuh/wazuh-indexer-common-utils/actions/runs/31481291684)) — revert where the original bump PR is found but the revert produces no changes: `Result: no changes to commit` is executed and no PR is created.

### Artifacts Affected

- `.github/workflows/5_bumper_repository.yml`

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

No automated tests. Validation is done via manual workflow runs as described above.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
